### PR TITLE
Articles in more than one category

### DIFF
--- a/google_sitemap_xml.php
+++ b/google_sitemap_xml.php
@@ -445,7 +445,7 @@ function getProducts($limit)
                 ".($mod_cnf['expired'] == true ? '': 'seo.oxexpired = 0 AND ')."
                 seo.oxstdurl LIKE ('%cnid=%')
             GROUP BY
-                oxart.oxid
+                seo.oxseourl
             LIMIT ".$start." OFFSET ".$end.";";
                        
     $sql_query = mysql_query($sql);


### PR DESCRIPTION
Grouping by oxarticles.oxid works well for articles which are listed in only one category but articles listed in more than one category will not be included in the sitemap.xml. Grouping by oxseo.oxseourl should list these multiple occurrences as well.
